### PR TITLE
fix: Tag account & OAuth config with correct visibility

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -250,19 +250,29 @@ export class HttpError extends Error {
 
 /** @public */
 export type PagerDutyOAuthConfig = {
+    /** @visibility backend */
     clientId: string;
+    /** @visibility secret */
     clientSecret: string;
+    /** @visibility frontend */
     region?: string;
+    /** @visibility frontend */
     subDomain: string;
 }
 
 /** @public */
 export type PagerDutyAccountConfig = {
+    /** @visibility frontend */
     id: string;
+    /** @visibility frontend */
     isDefault?: boolean;
+    /** @visibility frontend */
     eventsBaseUrl?: string;
+    /** @visibility frontend */
     apiBaseUrl?: string;
+    /** @visibility secret */
     apiToken?: string;
+    /** @visibility frontend */
     oauth?: PagerDutyOAuthConfig;
 }
 


### PR DESCRIPTION
### Description
The Config interface previously used `@deepvisibility secret` for both PagerDutyOAuthConfig & PagerDutyAccountConfig, which leads to many of the common strings being accidently redacted in the logs.

Of particular pain is `region`, which is commonly `us`, causing every mention of those characters, e.g. in `user` to be redacted as `***er`.

Fixing this requires declaring explicit visibility for the fields in the type, as well as updating the fields in the Config interface.

Signed-off-by: Robin H. Johnson <rjohnson@coreweave.com>
Reference: https://github.com/PagerDuty/backstage-plugin-monorepo/issues/28

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented
- [ ] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [n/a] I have documented the migration process
- [n/a] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
